### PR TITLE
refactor: Move example data seed function to repository

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -2,6 +2,7 @@ package pricing
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
@@ -50,5 +51,59 @@ func (mr *MockRepository) GetBrand(ctx context.Context, name string) (Brand, err
 }
 
 func (mr *MockRepository) Shutdown(ctx context.Context) error {
+	return nil
+}
+
+func SeedExampleData(ctx context.Context, repo Repository) error {
+	t1, err := time.Parse("2006-01-02-15.04.05", "2020-06-14-00.00.00")
+	if err != nil {
+		return fmt.Errorf("failed to parse time: %w", err)
+	}
+	t2, err := time.Parse("2006-01-02-15.04.05", "2020-12-31-23.59.59")
+	if err != nil {
+		return fmt.Errorf("failed to parse time: %w", err)
+	}
+	t3, err := time.Parse("2006-01-02-15.04.05", "2020-06-14-15.00.00")
+	if err != nil {
+		return fmt.Errorf("failed to parse time: %w", err)
+	}
+	t4, err := time.Parse("2006-01-02-15.04.05", "2020-06-14-18.30.00")
+	if err != nil {
+		return fmt.Errorf("failed to parse time: %w", err)
+	}
+	t5, err := time.Parse("2006-01-02-15.04.05", "2020-06-15-00.00.00")
+	if err != nil {
+		return fmt.Errorf("failed to parse time: %w", err)
+	}
+	t6, err := time.Parse("2006-01-02-15.04.05", "2020-06-15-11.00.00")
+	if err != nil {
+		return fmt.Errorf("failed to parse time: %w", err)
+	}
+	t7, err := time.Parse("2006-01-02-15.04.05", "2020-06-15-16.00.00")
+	if err != nil {
+		return fmt.Errorf("failed to parse time: %w", err)
+	}
+	t8, err := time.Parse("2006-01-02-15.04.05", "2020-12-31-23.59.59")
+	if err != nil {
+		return fmt.Errorf("failed to parse time: %w", err)
+	}
+
+	prices := []Price{
+		{BrandID: 1, StartDate: t1.UTC(), EndDate: t2.UTC(), ProductID: 35455, Priority: 0, Price: 3550, Curr: "EUR"},
+		{BrandID: 1, StartDate: t3.UTC(), EndDate: t4.UTC(), ProductID: 35455, Priority: 1, Price: 2545, Curr: "EUR"},
+		{BrandID: 1, StartDate: t5.UTC(), EndDate: t6.UTC(), ProductID: 35455, Priority: 1, Price: 3050, Curr: "EUR"},
+		{BrandID: 1, StartDate: t7.UTC(), EndDate: t8.UTC(), ProductID: 35455, Priority: 1, Price: 3895, Curr: "EUR"},
+	}
+
+	if err := repo.AddBrand(ctx, "EXAMPLE"); err != nil {
+		return fmt.Errorf("failed to add brand: %w", err)
+	}
+
+	for _, price := range prices {
+		if err := repo.AddPrice(ctx, price); err != nil {
+			return fmt.Errorf("failed to add an initial price to repository: %w", err)
+		}
+	}
+
 	return nil
 }

--- a/server.go
+++ b/server.go
@@ -51,22 +51,13 @@ func NewApp(args []string) (*App, error) {
 
 		repo = imr
 	}
-	svc := NewService(repo)
 
-	seedPrices, err := initialPrices()
+	err := SeedExampleData(ctx, repo)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse initial pricing data: %w", err)
+		return nil, fmt.Errorf("failed to seed example data")
 	}
 
-	if err := svc.repo.AddBrand(ctx, "EXAMPLE"); err != nil {
-		return nil, fmt.Errorf("failed to add brand: %w", err)
-	}
-
-	for _, price := range seedPrices {
-		if err := svc.repo.AddPrice(ctx, price); err != nil {
-			return nil, fmt.Errorf("failed to add an initial price to repository: %w", err)
-		}
-	}
+	svc := NewService(repo)
 
 	handler, err := NewHandler(svc)
 	if err != nil {
@@ -126,46 +117,4 @@ func (app *App) Run(ctx context.Context) error {
 	})
 
 	return group.Wait()
-}
-
-func initialPrices() ([]Price, error) {
-	t1, err := time.Parse("2006-01-02-15.04.05", "2020-06-14-00.00.00")
-	if err != nil {
-		return nil, err
-	}
-	t2, err := time.Parse("2006-01-02-15.04.05", "2020-12-31-23.59.59")
-	if err != nil {
-		return nil, err
-	}
-	t3, err := time.Parse("2006-01-02-15.04.05", "2020-06-14-15.00.00")
-	if err != nil {
-		return nil, err
-	}
-	t4, err := time.Parse("2006-01-02-15.04.05", "2020-06-14-18.30.00")
-	if err != nil {
-		return nil, err
-	}
-	t5, err := time.Parse("2006-01-02-15.04.05", "2020-06-15-00.00.00")
-	if err != nil {
-		return nil, err
-	}
-	t6, err := time.Parse("2006-01-02-15.04.05", "2020-06-15-11.00.00")
-	if err != nil {
-		return nil, err
-	}
-	t7, err := time.Parse("2006-01-02-15.04.05", "2020-06-15-16.00.00")
-	if err != nil {
-		return nil, err
-	}
-	t8, err := time.Parse("2006-01-02-15.04.05", "2020-12-31-23.59.59")
-	if err != nil {
-		return nil, err
-	}
-
-	return []Price{
-		{BrandID: 1, StartDate: t1.UTC(), EndDate: t2.UTC(), ProductID: 35455, Priority: 0, Price: 3550, Curr: "EUR"},
-		{BrandID: 1, StartDate: t3.UTC(), EndDate: t4.UTC(), ProductID: 35455, Priority: 1, Price: 2545, Curr: "EUR"},
-		{BrandID: 1, StartDate: t5.UTC(), EndDate: t6.UTC(), ProductID: 35455, Priority: 1, Price: 3050, Curr: "EUR"},
-		{BrandID: 1, StartDate: t7.UTC(), EndDate: t8.UTC(), ProductID: 35455, Priority: 1, Price: 3895, Curr: "EUR"},
-	}, nil
 }


### PR DESCRIPTION
Related to `type Repository interface {}` rather than the `type Server struct{}`.